### PR TITLE
Change object_id from BigIntegerField to CharField

### DIFF
--- a/deletion_records/migrations/0002_alter_deletedrecord_object_id.py
+++ b/deletion_records/migrations/0002_alter_deletedrecord_object_id.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("deletion_records", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="deletedrecord",
+            name="object_id",
+            field=models.CharField(verbose_name="object id"),
+        ),
+    ]

--- a/deletion_records/models.py
+++ b/deletion_records/models.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class DeletedRecord(models.Model):
     data = models.JSONField(_("data"))
     table_name = models.CharField(_("table name"), max_length=128)
-    object_id = models.BigIntegerField(_("object id"))
+    object_id = models.CharField(_("object id"))
     deleted_at = models.DateTimeField(_("deleted at"))
 
     class Meta:


### PR DESCRIPTION
I have a small change to propose in order to enable logging deleted objects that do not use an Integer as primary key. 